### PR TITLE
fixed text overflow on replies

### DIFF
--- a/lib/message.dart
+++ b/lib/message.dart
@@ -97,18 +97,23 @@ class MessagePageState extends State<MessagePage> {
               children: [
                 const SizedBox(width: 20),
                 const Icon(Icons.subdirectory_arrow_right_rounded, size: 36),
-                Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(10),
-                    child: Column(
-                      children: [
-                        Text(
-                          "${r["owner"]["firstname"]} ${r["owner"]["lastname"]}: ",
-                          style: const TextStyle(fontSize: 18),
-                          textAlign: TextAlign.left,
-                        ),
-                        Text(r["text"])
-                      ],
+                Expanded(
+                  child: Card(
+                    elevation: 2,
+                    child: Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Column(
+                        children: [
+                          Text(
+                            "${r["owner"]["firstname"]} ${r["owner"]["lastname"]}: ",
+                            style: const TextStyle(fontSize: 18),
+                            textAlign: TextAlign.left,
+                          ),
+                          Text(
+                            r["text"],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/lib/messages.dart
+++ b/lib/messages.dart
@@ -137,8 +137,12 @@ class TimeTablePageState extends State<MessagesPage> {
                     children: [
                       const SizedBox(width: 10),
                       const Icon(Icons.subdirectory_arrow_right_rounded),
-                      Text(
-                        r["owner"] + ": " + r["text"],
+                      Expanded(
+                        child: Text(
+                          r["owner"] + ": " + r["text"],
+                          overflow: TextOverflow.fade,
+                          softWrap: false,
+                        ),
                       ),
                     ],
                   ),


### PR DESCRIPTION
Text should not longer overflow on replies, instead on messages page it will fade (same as the message), and on the individual message page it will wrap if needed